### PR TITLE
fix(cli): 修复未闭合字符串字面量导致 SyntaxError (#4)

### DIFF
--- a/kuma_claw/cli.py
+++ b/kuma_claw/cli.py
@@ -30,10 +30,7 @@ console = Console()
 def print_banner():
     """打印 Banner"""
     console.print(Panel.fit(
-        f"[bold cyan]🦞 {i18n.t('banner_title')}[/bold cyan]
-
-"
-        f"[dim]{i18n.t('banner_desc')}[/dim]",
+        f"[bold cyan]🦞 {i18n.t('banner_title')}[/bold cyan]\n\n[dim]{i18n.t('banner_desc')}[/dim]",
         border_style="cyan"
     ))
 
@@ -179,13 +176,8 @@ def init(non_interactive: bool):
 
     console.print()
     console.print(Panel.fit(
-        f"[green]{i18n.t('init_done')}[/green]
-
-"
-        f"[cyan]{i18n.t('next_step')}[/cyan]
-"
-        f"  [bold]kuma-claw run --web[/bold]      {i18n.t('start_web')}
-"
+        f"[green]{i18n.t('init_done')}[/green]\n\n[cyan]{i18n.t('next_step')}[/cyan]\n"
+        f"  [bold]kuma-claw run --web[/bold]      {i18n.t('start_web')}\n"
         f"  [bold]kuma-claw run --telegram[/bold] {i18n.t('start_tg')}",
         title=i18n.t("success"),
         border_style="green"


### PR DESCRIPTION
## 问题描述
修复 CLI 中未闭合字符串字面量导致的 SyntaxError，阻塞所有命令执行。

## 修复内容
- 修复 print_banner() 中的多行 f-string 格式错误（第 32-36 行）
- 修复 init 命令成功提示中的字符串拼接问题（第 179-188 行）
- 使用 \n 显式换行替代错误的字符串打断

## 验证
✅ python3 -m py_compile 语法检查通过

Fixes #4