### PR TITLE
fix(deps): add aiohttp dependency for Slack channel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "requests>=2.31.0",
     "python-dotenv>=1.0.0",
     "ddgs>=9.0.0",
+    "aiohttp>=3.9.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## 问题描述

运行 `kuma-claw run --slack` 时崩溃：

```
ModuleNotFoundError: No module named 'aiohttp'
```

## 根本原因

- `slack-bolt` 在 Socket Mode 下使用 `AsyncSocketModeHandler` 时依赖 `aiohttp`
- `aiohttp` 是 slack-bolt 的可选依赖，未在 `pyproject.toml` 中显式声明
- 用户安装项目后无法启动 Slack 渠道

## 解决方案

在 `pyproject.toml` 的 `dependencies` 中添加：

```toml
"aiohttp>=3.9.0",
```

## 测试

安装后 Slack 渠道应能正常启动：

```bash
pip install -e .
kuma-claw run --slack
```

## 影响范围

- ✅ 修复 Slack 渠道无法启动的问题
- ✅ 无副作用，仅添加依赖
- ✅ 不影响其他渠道（Telegram、Web）

---

Fixes #6

**Co-authored-by: OpenClaw Assistant <assistant@openclaw.ai>**