### PR TITLE
feat(slack): isolate sessions by thread to prevent context pollution

### DIFF
--- a/kuma_claw/channels/base.py
+++ b/kuma_claw/channels/base.py
@@ -26,18 +26,28 @@ class SessionManager:
     def __init__(self, app_name: str = "kuma-claw"):
         self.app_name = app_name
         self.session_service = InMemorySessionService()
-        self.user_sessions: Dict[str, str] = {}
+        self.user_sessions: Dict[str, str] = {}  # session_key -> session_id
 
-    async def get_or_create_session(self, user_id: str) -> str:
-        """获取或创建用户会话
+    async def get_or_create_session(
+        self,
+        user_id: str,
+        session_key: Optional[str] = None
+    ) -> str:
+        """获取或创建会话
 
         Args:
             user_id: 用户 ID
+            session_key: 会话键（可选）
+                        - 格式："{user_id}:{channel}:{thread_id}"
+                        - 不传则使用 user_id 作为键
 
         Returns:
             会话 ID
         """
-        if user_id not in self.user_sessions:
+        # 使用 session_key 或 user_id 作为键
+        key = session_key or user_id
+
+        if key not in self.user_sessions:
             try:
                 session = await self.session_service.create_session(
                     app_name=self.app_name,
@@ -47,34 +57,37 @@ class SessionManager:
 
                 # 获取 session id
                 session_id = session.id if hasattr(session, 'id') else str(session)
-                self.user_sessions[user_id] = session_id
-                logger.debug(f"创建新会话: user={user_id}, session={session_id}")
+                self.user_sessions[key] = session_id
+                logger.debug(f"创建新会话: key={key}, session={session_id}")
 
             except Exception as e:
                 logger.error(f"创建会话失败: {e}")
                 raise
 
-        return self.user_sessions[user_id]
+        return self.user_sessions[key]
 
-    async def clear_session(self, user_id: str) -> bool:
-        """清除用户会话
+    async def clear_session(self, user_id: str, session_key: Optional[str] = None) -> bool:
+        """清除会话
 
         Args:
             user_id: 用户 ID
+            session_key: 会话键（可选）
 
         Returns:
             是否成功
         """
-        if user_id in self.user_sessions:
-            session_id = self.user_sessions[user_id]
+        key = session_key or user_id
+
+        if key in self.user_sessions:
+            session_id = self.user_sessions[key]
             try:
                 await self.session_service.delete_session(
                     app_name=self.app_name,
                     user_id=user_id,
                     session_id=session_id
                 )
-                del self.user_sessions[user_id]
-                logger.debug(f"清除会话: user={user_id}")
+                del self.user_sessions[key]
+                logger.debug(f"清除会话: key={key}")
                 return True
             except Exception as e:
                 logger.error(f"清除会话失败: {e}")
@@ -91,6 +104,7 @@ async def run_agent_with_session(
     session_manager: SessionManager,
     user_id: str,
     parts: List[types.Part],
+    session_key: Optional[str] = None,
 ) -> str:
     """运行 Agent 并返回响应
 
@@ -99,12 +113,16 @@ async def run_agent_with_session(
         session_manager: 会话管理器
         user_id: 用户 ID
         parts: 消息部分列表
+        session_key: 会话键（可选）
 
     Returns:
         Agent 响应文本
     """
     try:
-        session_id = await session_manager.get_or_create_session(user_id)
+        session_id = await session_manager.get_or_create_session(
+            user_id=user_id,
+            session_key=session_key
+        )
 
         content = types.Content(
             role="user",
@@ -180,7 +198,8 @@ class ChannelHandler(ABC):
         self,
         user_id: str,
         text: str,
-        images: List[Tuple[bytes, str]] = None
+        images: List[Tuple[bytes, str]] = None,
+        session_key: Optional[str] = None
     ) -> str:
         """运行 Agent（公共逻辑）
 
@@ -188,7 +207,9 @@ class ChannelHandler(ABC):
             user_id: 用户 ID
             text: 消息文本
             images: 图片列表，格式为 [(bytes, mime_type), ...]
-                   例如: [(b'\x89PNG...', 'image/png'), (b'\xff\xd8...', 'image/jpeg')]
+            session_key: 会话键（可选）
+                        - 用于隔离不同会话的上下文
+                        - 格式建议："{user_id}:{channel}:{thread_id}"
 
         Returns:
             Agent 响应
@@ -214,4 +235,5 @@ class ChannelHandler(ABC):
             session_manager=self.session_manager,
             user_id=user_id,
             parts=parts,
+            session_key=session_key,
         )

--- a/kuma_claw/channels/slack.py
+++ b/kuma_claw/channels/slack.py
@@ -81,6 +81,12 @@ class SlackChannel(ChannelHandler):
             # 移除 bot mention
             text = re.sub(r"<@[^>]+>", "", text).strip()
 
+            # 构造 session_key（按线程隔离）
+            # 格式："{user_id}:{channel}:{thread_ts}"
+            session_key = f"{user_id}:{channel}:{thread_ts}"
+
+            logger.debug(f"Slack 消息: user={user_id}, channel={channel}, thread={thread_ts}, session_key={session_key}")
+
             # 提取图片（如果有）
             files = event.get("files", [])
             images: List[Tuple[bytes, str]] = []
@@ -104,12 +110,13 @@ class SlackChannel(ChannelHandler):
                                 thread_ts=thread_ts
                             )
 
-            # 处理消息
+            # 处理消息（传入 session_key）
             try:
                 response = await self.run_agent(
                     user_id=user_id,
                     text=text,
                     images=images if images else None,
+                    session_key=session_key  # ← 关键：按线程隔离
                 )
 
                 # 提取内部内容


### PR DESCRIPTION
## 问题描述

同一用户的所有消息共享同一 session，导致在 Slack 中即使用户发送新消息（如 `@bot ?`），Agent 仍会延续上一话题（上下文污染）。

### 示例场景

```
User: @bot 帮我记住这个：我喜欢蓝色
Bot: 好的，我记住了。

（5分钟后）

User: @bot ?
Bot: 你刚才说你喜欢蓝色。（❌ 错误！新消息应该是空上下文）
```

## 根本原因

### 1. Session 只按 user_id 隔离
```python
# base.py (旧实现)
async def get_or_create_session(self, user_id: str) -> str:
    if user_id not in self.user_sessions:
        # 所有消息共享同一 session
        session = await self.session_service.create_session(...)
        self.user_sessions[user_id] = session.id
```

### 2. 忽略了 Slack 的线程结构
- **新顶层消息**：`thread_ts = event["ts"]` → 应该是新 session
- **线程内回复**：`thread_ts = event["thread_ts"]` → 应该是同一 session

## 解决方案

### 1. SessionManager 支持 session_key

```python
async def get_or_create_session(
    self,
    user_id: str,
    session_key: Optional[str] = None  # ← 新增
) -> str:
    """获取或创建会话

    Args:
        user_id: 用户 ID
        session_key: 会话键（可选）
                    - 格式："{user_id}:{channel}:{thread_id}"
                    - 不传则使用 user_id 作为键
    """
    key = session_key or user_id

    if key not in self.user_sessions:
        session = await self.session_service.create_session(...)
        self.user_sessions[key] = session.id

    return self.user_sessions[key]
```

### 2. Slack 渠道传入 thread_ts

```python
# slack.py
@self.app.event("app_mention")
async def handle_app_mention(body, client, logger_bolt):
    event = body["event"]
    channel = event["channel"]
    thread_ts = event.get("thread_ts") or event["ts"]
    user_id = event["user"]

    # 构造 session_key（按线程隔离）
    session_key = f"{user_id}:{channel}:{thread_ts}"

    # 处理消息
    response = await self.run_agent(
        user_id=user_id,
        text=text,
        session_key=session_key  # ← 传入
    )
```

## 行为变化

### 场景 1：新顶层消息（隔离）

```
消息 1:
  ts=100, thread_ts=100
  session_key="user:channel:100"
  → 新 session，空上下文

消息 2:
  ts=200, thread_ts=200
  session_key="user:channel:200"
  → 新 session，空上下文（✅ 不延续消息 1）
```

### 场景 2：线程内回复（延续）

```
消息 1:
  ts=100, thread_ts=100
  session_key="user:channel:100"

回复 1:
  ts=101, thread_ts=100  ← 同一线程
  session_key="user:channel:100"
  → 同一 session（✅ 延续上下文）
```

## 技术细节

### session_key 格式
```
{user_id}:{channel}:{thread_ts}
```

- **user_id**: Slack 用户 ID
- **channel**: 频道 ID
- **thread_ts**: 线程时间戳

### 为什么包含 channel？
- 同一用户在不同频道应该是不同会话
- 避免跨频道上下文污染

### thread_ts 来源
```python
thread_ts = event.get("thread_ts") or event["ts"]
```

- **新消息**：`thread_ts` 不存在 → 使用 `event["ts"]`
- **线程回复**：`thread_ts` 存在 → 使用原消息的时间戳

## 兼容性

### Telegram/Discord/Web
- 不传 `session_key` 参数
- 行为不变（按 user_id 隔离）

```python
# telegram.py (无需修改)
response = await self.run_agent(
    user_id=user_id,
    text=text
    # 不传 session_key，使用 user_id
)
```

### Slack
- 按 `{user_id}:{channel}:{thread_ts}` 隔离
- 解决上下文污染问题

## 测试

### 1. 启动 Slack Bot
```bash
kuma-claw run --slack
```

### 2. 测试场景 A：新消息隔离
1. 发送：`@bot 你好`（新消息）
2. 发送：`@bot ?`（新消息）
3. **预期**：第二个消息不延续第一个话题

### 3. 测试场景 B：线程内延续
1. 发送：`@bot 帮我记住这个：ABC`（新消息）
2. 回复：`我刚才说了什么？`（线程内回复）
3. **预期**：Agent 记得 "ABC"

### 4. 测试场景 C：跨频道隔离
1. 在 #general 发送：`@bot 我喜欢蓝色`
2. 在 #random 发送：`@bot 我刚才说了什么？`
3. **预期**：Agent 回答 "没有上下文"

## 影响范围

- ✅ **Slack 渠道**：解决上下文污染
- ✅ **其他渠道**：不受影响
- ✅ **向后兼容**：session_key 可选

## 后续优化

- [ ] 添加 session 过期机制（避免内存泄漏）
- [ ] 支持手动清除 session（`/clear` 命令）
- [ ] 日志记录 session 创建和销毁

---

Fixes #9

**Co-authored-by: OpenClaw Assistant <assistant@openclaw.ai>**
