### PR TITLE
fix(agent): support both ddgs and duckduckgo-search imports

### DIFF
--- a/kuma_claw/agent.py
+++ b/kuma_claw/agent.py
@@ -125,28 +125,62 @@ def get_memory_stats() -> str:
 
 def web_search(query: str, limit: int = 5) -> str:
     """通过 DuckDuckGo 搜索网络获取实时信息
-    
+
     Args:
         query: 搜索关键词
         limit: 返回的结果数量上限
-        
+
     Returns:
         包含标题、摘要和链接的搜索结果文本
     """
     try:
-        from duckduckgo_search import DDGS
-        results = []
-        with DDGS() as ddgs:
-            for r in ddgs.text(query, max_results=limit):
-                results.append(f"标题: {r.get('title')}\n内容: {r.get('body')}\n链接: {r.get('href')}")
-        
+        # 优先使用新包 ddgs
+        try:
+            from ddgs import DDGS
+            logger.debug("使用 ddgs 包（新）")
+
+            # 新包：直接返回 list
+            with DDGS() as ddgs:
+                results_raw = ddgs.text(query, max_results=limit)
+
+            results = []
+            for r in results_raw:
+                results.append(
+                    f"标题: {r.get('title')}\n"
+                    f"内容: {r.get('body')}\n"
+                    f"链接: {r.get('href')}"
+                )
+
+        except ImportError:
+            # 备选：旧包 duckduckgo_search
+            try:
+                from duckduckgo_search import DDGS
+                logger.debug("使用 duckduckgo-search 包（旧）")
+
+                # 旧包：需要 with 语句
+                results = []
+                with DDGS() as ddgs:
+                    for r in ddgs.text(query, max_results=limit):
+                        results.append(
+                            f"标题: {r.get('title')}\n"
+                            f"内容: {r.get('body')}\n"
+                            f"链接: {r.get('href')}"
+                        )
+
+            except ImportError:
+                return (
+                    "❌ 搜索功能不可用：未安装搜索库\n"
+                    "安装新包: pip install ddgs>=9.0.0\n"
+                    "或旧包: pip install duckduckgo-search"
+                )
+
         if not results:
             return f"没有找到关于 '{query}' 的搜索结果。"
-            
+
         return "\n\n".join(results)
-    except ImportError:
-        return "❌ 搜索功能不可用：未安装 duckduckgo-search 库\n安装: pip install duckduckgo-search"
+
     except Exception as e:
+        logger.error(f"搜索失败: {str(e)}")
         return f"搜索失败: {str(e)}"
 
 
@@ -156,7 +190,7 @@ def web_search(query: str, limit: int = 5) -> str:
 
 def _load_google_workspace_toolsets():
     """加载 ADK 内置的 Google Workspace 工具集
-    
+
     Returns:
         工具集列表（失败时返回空列表）
     """


### PR DESCRIPTION
## 问题描述

`web_search` 工具无法使用，报错「网络搜索工具暂时无法使用」。

## 根本原因

### 包名变更
- **pyproject.toml** 依赖：`ddgs>=9.0.0`（新包名）
- **agent.py** 导入：`from duckduckgo_search import DDGS`（旧包名）
- **事实**：`duckduckgo-search` 已重命名为 `ddgs`，导入路径和 API 不同

### API 差异
```python
# 新包 ddgs
from ddgs import DDGS
with DDGS() as ddgs:
    results = ddgs.text(query, max_results=limit)  # 返回 list

# 旧包 duckduckgo-search
from duckduckgo_search import DDGS
with DDGS() as ddgs:
    for r in ddgs.text(query, max_results=limit):  # 需要迭代
        ...
```

## 解决方案

### 1. 支持两种导入方式

```python
def web_search(query: str, limit: int = 5) -> str:
    """搜索网络"""
    try:
        # 优先使用新包 ddgs
        try:
            from ddgs import DDGS
            logger.debug("使用 ddgs 包（新）")

            with DDGS() as ddgs:
                results_raw = ddgs.text(query, max_results=limit)

            results = []
            for r in results_raw:
                results.append(
                    f"标题：{r.get('title')}\n"
                    f"内容：{r.get('body')}\n"
                    f"链接：{r.get('href')}"
                )

        except ImportError:
            # 备选：旧包 duckduckgo_search
            from duckduckgo_search import DDGS
            logger.debug("使用 duckduckgo-search 包（旧）")

            results = []
            with DDGS() as ddgs:
                for r in ddgs.text(query, max_results=limit):
                    results.append(
                        f"标题：{r.get('title')}\n"
                        f"内容：{r.get('body')}\n"
                        f"链接：{r.get('href')}"
                    )

    except ImportError:
        return (
            "❌ 搜索功能不可用：未安装搜索库\n"
            "安装新包：pip install ddgs>=9.0.0\n"
            "或旧包：pip install duckduckgo-search"
        )
```

### 2. 改进错误消息
- 显示两个包的安装命令
- 记录使用的是哪个包

## 兼容性

### 新包用户（ddgs）
```bash
pip install ddgs>=9.0.0
```
- ✅ 自动使用新包
- ✅ 日志显示 "使用 ddgs 包（新）"

### 旧包用户（duckduckgo-search）
```bash
pip install duckduckgo-search
```
- ✅ 自动回退到旧包
- ✅ 日志显示 "使用 duckduckgo-search 包（旧）"

### 未安装包
- ✅ 显示清晰的安装指引
- ✅ 同时列出两个包的安装命令

## 测试

### 1. 测试新包
```bash
pip install ddgs>=9.0.0
python -c "from kuma_claw.agent import web_search; print(web_search('Python 3.12'))"
```

**预期**：返回搜索结果

### 2. 测试旧包
```bash
pip uninstall ddgs -y
pip install duckduckgo-search
python -c "from kuma_claw.agent import web_search; print(web_search('Python 3.12'))"
```

**预期**：返回搜索结果

### 3. 测试错误消息
```bash
pip uninstall ddgs duckduckgo-search -y
python -c "from kuma_claw.agent import web_search; print(web_search('Python 3.12'))"
```

**预期**：显示安装指引

## 影响范围

- ✅ 新包用户：正常工作
- ✅ 旧包用户：向后兼容
- ✅ 未安装包：清晰错误消息

## 依赖说明

### pyproject.toml
```toml
dependencies = [
    "ddgs>=9.0.0",  # 推荐新包
]
```

### 可选依赖
```toml
[project.optional-dependencies]
search = [
    "ddgs>=9.0.0",
    # 或
    "duckduckgo-search>=5.0.0",
]
```

---

Fixes #10

**Co-authored-by: OpenClaw Assistant <assistant@openclaw.ai>**
