### PR TITLE
fix: P0 紧急修复 - config.py 重复定义和 test_skills.py 导入路径

### DIFF
--- a/kuma_claw/config.py
+++ b/kuma_claw/config.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Optional, Dict
 
 # 配置文件路径
-# 配置文件路径
 OLD_CONFIG_DIR = Path.home() / ".adk-claw"
 CONFIG_DIR = Path.home() / ".kuma-claw"
 
@@ -17,9 +16,9 @@ if OLD_CONFIG_DIR.exists() and not CONFIG_DIR.exists():
     import shutil
     try:
         shutil.copytree(str(OLD_CONFIG_DIR), str(CONFIG_DIR))
-        print(f"📦 [Kuma Claw] 自动迁移旧配置: {OLD_CONFIG_DIR} -> {CONFIG_DIR}")
+        print(f"📦 [Kuma Claw] 自动迁移旧配置：{OLD_CONFIG_DIR} -> {CONFIG_DIR}")
     except Exception as e:
-        print(f"⚠️ [Kuma Claw] 配置迁移失败: {e}")
+        print(f"⚠️ [Kuma Claw] 配置迁移失败：{e}")
 
 CONFIG_FILE = CONFIG_DIR / "config.json"
 SECRETS_FILE = CONFIG_DIR / "secrets.json"
@@ -168,30 +167,6 @@ class Config:
     def get_google_oauth_client_secret(self) -> Optional[str]:
         """获取 Google OAuth Client Secret"""
         return self.secrets.get("google_oauth_client_secret")
-    
-    # ============================================
-    # 状态检查
-    # ============================================
-    
-    def get_google_api_key(self) -> Optional[str]:
-        """获取 Google API Key"""
-        return self.secrets.get("google_api_key") or os.environ.get("GOOGLE_API_KEY")
-    
-    def get_openai_api_key(self) -> Optional[str]:
-        """获取 OpenAI API Key"""
-        return self.secrets.get("openai_api_key") or os.environ.get("OPENAI_API_KEY")
-    
-    def get_anthropic_api_key(self) -> Optional[str]:
-        """获取 Anthropic API Key"""
-        return self.secrets.get("anthropic_api_key") or os.environ.get("ANTHROPIC_API_KEY")
-    
-    def is_slack_enabled(self) -> bool:
-        """Slack 是否启用"""
-        return bool(self.get_slack_bot_token())
-    
-    def is_telegram_enabled(self) -> bool:
-        """Telegram 是否启用"""
-        return bool(self.get_telegram_token())
 
 
 # 全局配置实例

--- a/test_skills.py
+++ b/test_skills.py
@@ -9,9 +9,14 @@ import sys
 from pathlib import Path
 
 # 添加项目路径
-sys.path.insert(0, str(Path(__file__).parent))
+PROJECT_ROOT = Path(__file__).parent
+sys.path.insert(0, str(PROJECT_ROOT))
 
-from kuma_claw.skills.kuma-skills-system.scripts.skill_manager import SkillManager
+# 添加 skills 脚本路径（目录名含连字符，需特殊处理）
+SKILLS_SCRIPTS_DIR = PROJECT_ROOT / "skills" / "kuma-skills-system" / "scripts"
+sys.path.insert(0, str(SKILLS_SCRIPTS_DIR))
+
+from skill_manager import SkillManager
 
 
 def test_skill_manager():
@@ -19,7 +24,7 @@ def test_skill_manager():
     print("🧪 测试 SkillManager...")
 
     # 初始化
-    skills_dir = Path(__file__).parent / "kuma_claw" / "skills"
+    skills_dir = PROJECT_ROOT / "kuma_claw" / "skills"
     manager = SkillManager(skills_dir=skills_dir)
 
     # 列出 skills
@@ -50,7 +55,7 @@ def test_skill_manager():
 
     # 获取所有提示词
     prompts = manager.get_all_prompts()
-    print(f"\n📝 提示词长度: {len(prompts)} 字符")
+    print(f"\n📝 提示词长度：{len(prompts)} 字符")
 
     return True
 
@@ -68,7 +73,7 @@ def test_weather_skill():
 
         return True
     except Exception as e:
-        print(f"\n❌ Weather skill 测试失败: {e}")
+        print(f"\n❌ Weather skill 测试失败：{e}")
         return False
 
 
@@ -84,14 +89,14 @@ def main():
     try:
         results.append(("SkillManager", test_skill_manager()))
     except Exception as e:
-        print(f"\n❌ SkillManager 测试失败: {e}")
+        print(f"\n❌ SkillManager 测试失败：{e}")
         results.append(("SkillManager", False))
 
     # 测试 2: Weather Skill
     try:
         results.append(("Weather Skill", test_weather_skill()))
     except Exception as e:
-        print(f"\n❌ Weather Skill 测试失败: {e}")
+        print(f"\n❌ Weather Skill 测试失败：{e}")
         results.append(("Weather Skill", False))
 
     # 总结


### PR DESCRIPTION
## 修复内容

### #22 - config.py 中多个方法重复定义
- 移除重复的注释行
- 移除重复定义的方法 (get_google_api_key, get_openai_api_key, get_anthropic_api_key, is_slack_enabled, is_telegram_enabled)

### #24 - test_skills.py 导入路径含连字符
- 修正 skill_manager 导入路径，支持连字符目录名

## 关联 Issue
- Closes #22
- Closes #24