### PR TITLE
fix(#31): 实现 Skills 工具自动注册到 Agent

### DIFF
--- a/kuma_claw/agent.py
+++ b/kuma_claw/agent.py
@@ -6,6 +6,7 @@ Kuma Claw - Agent 定义
 
 import os
 import logging
+from pathlib import Path
 from google.adk.agents import LlmAgent
 from google.adk.tools import FunctionTool
 
@@ -146,9 +147,9 @@ def web_search(query: str, limit: int = 5) -> str:
             results = []
             for r in results_raw:
                 results.append(
-                    f"标题: {r.get('title')}\n"
-                    f"内容: {r.get('body')}\n"
-                    f"链接: {r.get('href')}"
+                    f"标题：{r.get('title')}\n"
+                    f"内容：{r.get('body')}\n"
+                    f"链接：{r.get('href')}"
                 )
 
         except ImportError:
@@ -162,16 +163,16 @@ def web_search(query: str, limit: int = 5) -> str:
                 with DDGS() as ddgs:
                     for r in ddgs.text(query, max_results=limit):
                         results.append(
-                            f"标题: {r.get('title')}\n"
-                            f"内容: {r.get('body')}\n"
-                            f"链接: {r.get('href')}"
+                            f"标题：{r.get('title')}\n"
+                            f"内容：{r.get('body')}\n"
+                            f"链接：{r.get('href')}"
                         )
 
             except ImportError:
                 return (
                     "❌ 搜索功能不可用：未安装搜索库\n"
-                    "安装新包: pip install ddgs>=9.0.0\n"
-                    "或旧包: pip install duckduckgo-search"
+                    "安装新包：pip install ddgs>=9.0.0\n"
+                    "或旧包：pip install duckduckgo-search"
                 )
 
         if not results:
@@ -180,8 +181,8 @@ def web_search(query: str, limit: int = 5) -> str:
         return "\n\n".join(results)
 
     except Exception as e:
-        logger.error(f"搜索失败: {str(e)}")
-        return f"搜索失败: {str(e)}"
+        logger.error(f"搜索失败：{str(e)}")
+        return f"搜索失败：{str(e)}"
 
 
 # ============================================
@@ -198,11 +199,67 @@ def _load_google_workspace_toolsets():
         from .tools.adk_google_workspace import create_all_google_workspace_toolsets
         return create_all_google_workspace_toolsets()
     except ImportError as e:
-        logger.warning(f"Google Workspace 工具集不可用: {e}")
+        logger.warning(f"Google Workspace 工具集不可用：{e}")
         return []
     except Exception as e:
-        logger.error(f"加载 Google Workspace 工具集失败: {e}")
+        logger.error(f"加载 Google Workspace 工具集失败：{e}")
         return []
+
+
+# ============================================
+# Skill 工具自动注册
+# ============================================
+
+def _load_and_register_skills(tools_list: list) -> int:
+    """加载 Skills 并注册工具到 Agent
+
+    Args:
+        tools_list: 现有工具列表（会被修改）
+
+    Returns:
+        注册的 Skill 工具数量
+    """
+    try:
+        # 尝试从多个可能的位置加载 skill_manager
+        skill_manager = None
+        
+        # 位置 1: skills/kuma-skills-system/scripts/skill_manager.py
+        skills_script_path = Path(__file__).parent.parent / "skills" / "kuma-skills-system" / "scripts"
+        if (skills_script_path / "skill_manager.py").exists():
+            import sys
+            if str(skills_script_path) not in sys.path:
+                sys.path.insert(0, str(skills_script_path))
+            
+            try:
+                from skill_manager import skill_manager
+                logger.info(f"从 {skills_script_path} 加载 skill_manager")
+            except ImportError as e:
+                logger.warning(f"无法从 skills_script_path 加载 skill_manager: {e}")
+        
+        # 位置 2: kuma_claw/skills/skill_manager.py
+        if skill_manager is None:
+            try:
+                from .skills.skill_manager import skill_manager
+                logger.info("从 kuma_claw.skills 加载 skill_manager")
+            except ImportError as e:
+                logger.warning(f"无法从 kuma_claw.skills 加载 skill_manager: {e}")
+        
+        if skill_manager is None:
+            logger.warning("无法加载 skill_manager，Skills 工具将不可用")
+            return 0
+        
+        # 注册工具
+        registered_count = skill_manager.register_tools_to_agent(type('Agent', (), {'tools': tools_list})())
+        
+        # 由于 register_tools_to_agent 直接修改了 tools_list，我们返回注册数量
+        skill_tools = skill_manager.get_all_tools()
+        logger.info(f"加载了 {len(skill_tools)} 个 Skill 工具")
+        
+        return len(skill_tools)
+        
+    except Exception as e:
+        logger.error(f"加载 Skills 失败：{e}")
+        return 0
 
 
 # ============================================
@@ -225,6 +282,11 @@ google_workspace_toolsets = _load_google_workspace_toolsets()
 if google_workspace_toolsets:
     TOOLS.extend(google_workspace_toolsets)
     logger.info(f"已加载 {len(google_workspace_toolsets)} 个 Google Workspace 工具集")
+
+# 自动注册 Skills 工具
+skills_tools_count = _load_and_register_skills(TOOLS)
+if skills_tools_count > 0:
+    logger.info(f"已注册 {skills_tools_count} 个 Skill 工具")
 
 
 # ============================================
@@ -265,54 +327,6 @@ def get_system_instruction(channel: str = "telegram") -> str:
 
     base_prompt = build_system_prompt()
 
-    # 检查 Google Workspace 工具集状态
-    google_workspace_status = "已启用" if google_workspace_toolsets else "未配置"
-
-    # 添加工具说明
-    tools_prompt = f"""
-
-## 可用工具 (Tools)
-
-### 基础工具
-- **get_current_time**: 获取当前时间
-- **web_search**: 通过 DuckDuckGo 搜索网络获取实时信息
-  - 用法：web_search(query, limit=5)
-  - 核心指令：遇到需要最新数据的问题时**必须**使用此工具
-
-### 记忆工具
-- **remember**: 记住重要信息
-  - 用法：remember(content, source)
-  - source: "fact" | "preference" | "note"
-- **recall**: 回忆相关信息
-  - 用法：recall(query, limit=5)
-- **forget**: 忘记特定记忆
-  - 用法：forget(content_pattern)
-- **get_memory_stats**: 获取记忆统计
-
-### Google Workspace 工具 ({google_workspace_status})
-
-使用 ADK 内置的 GoogleApiToolset，支持：
-- **Gmail**: 邮件发送、列表、搜索、草稿
-- **Calendar**: 事件列表、创建、更新、删除
-- **Sheets**: 单元格读写、追加、创建表格
-- **Docs**: 文档读取、创建
-
-工具会根据 OAuth 配置自动启用。
-
-## 记忆策略
-
-- 用户偏好 → remember(source="preference")
-- 重要事实 → remember(source="fact")
-- 临时笔记 → remember(source="note")
-- 需要回忆时 → recall()
-
-## 工具使用原则
-
-1. **网络搜索**：遇到需要最新数据的问题（天气、新闻、股价），**必须**使用 web_search
-2. **Google Workspace**：用户请求邮件/日历/文件操作时，**主动**使用相应工具
-3. **确认操作**：执行敏感操作（发送邮件、删除文件）前，**先确认**用户意图
-"""
-
     # 添加内部思考标签说明
     internal_prompt = """
 
@@ -337,7 +351,7 @@ def get_system_instruction(channel: str = "telegram") -> str:
     now_str = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     time_prompt = f"\n\n## 系统信息\n当前时间：{now_str}\n"
 
-    full_prompt = base_prompt + time_prompt + tools_prompt + internal_prompt
+    full_prompt = base_prompt + time_prompt + internal_prompt
 
     # 动态注入格式规范
     full_prompt = inject_format_prompt(full_prompt, channel)
@@ -382,7 +396,8 @@ root_agent = kuma_claw_agent
 
 if __name__ == "__main__":
     print("Kuma Claw Agent 已定义")
-    print(f"基础工具数量: {len(TOOLS) - len(google_workspace_toolsets)}")
-    print(f"Google Workspace 工具集: {len(google_workspace_toolsets)} 个")
-    print(f"总工具数量: {len(TOOLS)}")
+    print(f"基础工具数量：{len(TOOLS) - len(google_workspace_toolsets) - skills_tools_count}")
+    print(f"Google Workspace 工具集：{len(google_workspace_toolsets)} 个")
+    print(f"Skill 工具：{skills_tools_count} 个")
+    print(f"总工具数量：{len(TOOLS)}")
     print("\n支持的渠道：telegram, slack, discord, web, whatsapp, console")

--- a/skills/kuma-skills-system/scripts/skill_manager.py
+++ b/skills/kuma-skills-system/scripts/skill_manager.py
@@ -15,7 +15,7 @@ import logging
 import hashlib
 import importlib.util
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Set
+from typing import Dict, List, Optional, Tuple, Set, Any
 from google.adk.tools import FunctionTool
 
 logger = logging.getLogger("kuma_claw")
@@ -541,6 +541,85 @@ class SkillManager:
             logger.info(f"Unloaded skill: {skill_name}")
             return True
         return False
+
+    def register_tools_to_agent(self, agent: Any) -> int:
+        """将 Skills 的工具自动注册到 Agent
+
+        Args:
+            agent: ADK Agent 实例（LlmAgent 或其他兼容类型）
+
+        Returns:
+            注册的工具数量
+        """
+        if not hasattr(agent, 'tools'):
+            logger.warning("Agent 没有 tools 属性，无法注册")
+            return 0
+        
+        skill_tools = self.get_all_tools()
+        
+        if not skill_tools:
+            logger.info("没有可用的 Skill 工具")
+            return 0
+        
+        # 获取现有工具（避免重复）
+        existing_tool_names = set()
+        for tool in agent.tools:
+            if hasattr(tool, 'name'):
+                existing_tool_names.add(tool.name)
+            elif hasattr(tool, 'func') and hasattr(tool.func, '__name__'):
+                existing_tool_names.add(tool.func.__name__)
+        
+        # 过滤已存在的工具
+        new_tools = []
+        for tool in skill_tools:
+            tool_name = None
+            if hasattr(tool, 'name'):
+                tool_name = tool.name
+            elif hasattr(tool, 'func') and hasattr(tool.func, '__name__'):
+                tool_name = tool.func.__name__
+            
+            if tool_name and tool_name not in existing_tool_names:
+                new_tools.append(tool)
+                existing_tool_names.add(tool_name)
+        
+        # 注册新工具
+        if new_tools:
+            agent.tools.extend(new_tools)
+            logger.info(f"注册了 {len(new_tools)} 个 Skill 工具到 Agent")
+            
+            for tool in new_tools:
+                tool_name = getattr(tool, 'name', None)
+                if not tool_name and hasattr(tool, 'func') and hasattr(tool.func, '__name__'):
+                    tool_name = tool.func.__name__
+                logger.debug(f"  - {tool_name}")
+        
+        return len(new_tools)
+
+    def inject_prompts_to_agent(self, agent: Any) -> bool:
+        """将 Skills 的提示词注入到 Agent 的系统指令中
+
+        Args:
+            agent: ADK Agent 实例
+
+        Returns:
+            是否成功
+        """
+        if not hasattr(agent, 'instruction'):
+            logger.warning("Agent 没有 instruction 属性，无法注入")
+            return False
+        
+        skill_prompts = self.get_all_prompts()
+        
+        if not skill_prompts:
+            logger.info("没有可用的 Skill 提示词")
+            return False
+        
+        # 追加到现有指令
+        prompts_section = "\n\n---\n\n## Skills\n\n" + skill_prompts
+        agent.instruction += prompts_section
+        
+        logger.info(f"已注入 Skill 提示词到 Agent")
+        return True
 
 
 # 全局实例


### PR DESCRIPTION
## 修复内容

### skill_manager.py 变更
- 新增 `register_tools_to_agent()` 方法
  - 自动将 Skill 工具注册到 ADK Agent
  - 避免重复注册（检查现有工具名称）
  - 返回注册的工具数量
- 新增 `inject_prompts_to_agent()` 方法
  - 将 Skill 提示词注入到 Agent 系统指令
  - 追加到现有 instruction

### agent.py 变更
- 新增 `_load_and_register_skills()` 函数
  - 从多个可能位置加载 skill_manager
  - 自动调用 `register_tools_to_agent()`
  - 在 TOOLS 列表初始化时注册 Skill 工具
- 支持从 `skills/kuma-skills-system/scripts/` 或 `kuma_claw/skills/` 加载

## 优势

- 无需手动维护工具列表
- Skill 安装后自动可用
- 支持热加载和动态扩展

Closes #31