### PR TITLE
fix: 提升 session 日志级别为 info，方便调试 ADK 调用

### DIFF
--- a/kuma_claw/sessions.py
+++ b/kuma_claw/sessions.py
@@ -201,7 +201,7 @@ class SQLiteSessionService(BaseSessionService):
             logger.warning(f"更新会话失败：id={session_id} (不存在)")
             return None
         
-        logger.debug(f"更新会话：id={session_id}, state={state}")
+        logger.info(f"更新会话：id={session_id}, state={state}")
         return Session(
             id=session_id,
             app_name=app_name,


### PR DESCRIPTION
**目的：** 确认 ADK 是否调用了  和 

**修改：**
-  日志从 debug 改为 info
-  日志从 debug 改为 info
-  日志从 debug 改为 info

**测试：**
在 GCP 上 merge 后重启 bot，查看日志中是否有：
- '获取会话' 或 '复用已有会话'
- '更新会话'

如果没有'更新会话'，说明 ADK 没有调用 ，需要进一步调查。