### PR TITLE
fix: 批量修复 Issues #103 #106 #107 #108 #109 #111（安全漏洞、架构重构、代码质量、依赖管理）

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+# Pre-commit hooks 配置（Issue #111）
+# 安装方式：pip install pre-commit && pre-commit install
+# 手动运行：pre-commit run --all-files
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+        args: [--ignore-missing-imports]
+        additional_dependencies: [types-requests]
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-added-large-files
+        args: [--maxkb=500]
+      - id: check-merge-conflict
+      - id: debug-statements

--- a/kuma_claw/agent.py
+++ b/kuma_claw/agent.py
@@ -18,47 +18,66 @@ from google.adk.tools import FunctionTool
 logger = logging.getLogger("kuma_claw")
 
 # ============================================
-# 懒加载缓存（带 TTL 失效机制）
+# 缓存管理器（Issue #106：将全局变量重构为单例类）
 # ============================================
-
-_model_cache: Any | None = None
-_model_cache_time: float = 0
-_google_workspace_toolsets_cache: list | None = None
-_google_workspace_cache_time: float = 0
-_skill_manager_cache: Any | None = None
-_agent_cache: LlmAgent | None = None
-_agent_cache_time: float = 0
 
 # 缓存 TTL（秒）
 CACHE_TTL = 300  # 5 分钟
 
 
+class AgentCache:
+    """单例缓存管理器
+
+    将原来分散的 6 个全局变量封装为单一类，
+    提高可测试性和并发安全性。
+    """
+
+    _instance: Optional["AgentCache"] = None
+
+    def __new__(cls) -> "AgentCache":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._init()
+        return cls._instance
+
+    def _init(self):
+        self.model_cache: Any | None = None
+        self.model_cache_time: float = 0
+        self.google_workspace_toolsets_cache: list | None = None
+        self.google_workspace_cache_time: float = 0
+        self.skill_manager_cache: Any | None = None
+        self.agent_cache: LlmAgent | None = None
+        self.agent_cache_time: float = 0
+
+    def reset(self):
+        """重置所有缓存"""
+        self._init()
+
+    def is_valid(self, cache_time: float) -> bool:
+        """检查缓存是否有效"""
+        if cache_time == 0:
+            return False
+        return (time.time() - cache_time) < CACHE_TTL
+
+
+# 全局缓存实例
+_cache = AgentCache()
+
+
 def reset_cache():
-    """重置所有缓存"""
-    global _agent_cache, _google_workspace_toolsets_cache, _model_cache, _skill_manager_cache
-    global _agent_cache_time, _google_workspace_cache_time, _model_cache_time
-    _model_cache = None
-    _model_cache_time = 0
-    _agent_cache = None
-    _agent_cache_time = 0
-    _google_workspace_toolsets_cache = None
-    _google_workspace_cache_time = 0
-    _skill_manager_cache = None
+    """重置所有缓存（向后兼容）"""
+    _cache.reset()
 
 
 def _is_cache_valid(cache_time: float) -> bool:
-    """检查缓存是否有效"""
-    if cache_time == 0:
-        return False
-    return (time.time() - cache_time) < CACHE_TTL
+    """检查缓存是否有效（向后兼容）"""
+    return _cache.is_valid(cache_time)
 
 
 def get_model():
     """获取模型配置（懒加载 + TTL 缓存）"""
-    global _model_cache, _model_cache_time
-
-    if _model_cache is not None and _is_cache_valid(_model_cache_time):
-        return _model_cache
+    if _cache.model_cache is not None and _cache.is_valid(_cache.model_cache_time):
+        return _cache.model_cache
 
     try:
         from .config import config
@@ -70,12 +89,12 @@ def get_model():
     if isinstance(model, str) and model.startswith(("openai/", "anthropic/", "deepseek/")):
         from google.adk.models.lite_llm import LiteLlm
 
-        _model_cache = LiteLlm(model=model)
+        _cache.model_cache = LiteLlm(model=model)
     else:
-        _model_cache = model
+        _cache.model_cache = model
 
-    _model_cache_time = time.time()
-    return _model_cache
+    _cache.model_cache_time = time.time()
+    return _cache.model_cache
 
 
 # ============================================
@@ -167,27 +186,25 @@ def web_search(query: str, limit: int = 5) -> str:
 
 def _load_google_workspace_toolsets():
     """加载 Google Workspace 工具集（懒加载 + TTL 缓存）"""
-    global _google_workspace_toolsets_cache, _google_workspace_cache_time
-
-    if _google_workspace_toolsets_cache is not None and _is_cache_valid(
-        _google_workspace_cache_time
+    if _cache.google_workspace_toolsets_cache is not None and _cache.is_valid(
+        _cache.google_workspace_cache_time
     ):
-        return _google_workspace_toolsets_cache
+        return _cache.google_workspace_toolsets_cache
 
     try:
         from .tools.adk_google_workspace import create_all_google_workspace_toolsets
 
-        _google_workspace_toolsets_cache = create_all_google_workspace_toolsets()
-        logger.info(f"已加载 {len(_google_workspace_toolsets_cache)} 个 Google Workspace 工具集")
+        _cache.google_workspace_toolsets_cache = create_all_google_workspace_toolsets()
+        logger.info(f"已加载 {len(_cache.google_workspace_toolsets_cache)} 个 Google Workspace 工具集")
     except ImportError:
         logger.warning("Google Workspace 工具集不可用")
-        _google_workspace_toolsets_cache = []
+        _cache.google_workspace_toolsets_cache = []
     except Exception as e:
         logger.error(f"加载 Google Workspace 工具集失败：{e}")
-        _google_workspace_toolsets_cache = []
+        _cache.google_workspace_toolsets_cache = []
 
-    _google_workspace_cache_time = time.time()
-    return _google_workspace_toolsets_cache
+    _cache.google_workspace_cache_time = time.time()
+    return _cache.google_workspace_toolsets_cache
 
 
 # ============================================
@@ -197,19 +214,18 @@ def _load_google_workspace_toolsets():
 
 def _get_skill_manager():
     """获取 SkillManager 实例"""
-    global _skill_manager_cache
-    if _skill_manager_cache is not None:
-        return _skill_manager_cache
+    if _cache.skill_manager_cache is not None:
+        return _cache.skill_manager_cache
 
     try:
         from .skills.skill_manager import skill_manager
 
-        _skill_manager_cache = skill_manager
-        logger.debug(f"SkillManager 加载完成，技能数量: {len(_skill_manager_cache.skills)}")
+        _cache.skill_manager_cache = skill_manager
+        logger.debug(f"SkillManager 加载完成，技能数量: {len(_cache.skill_manager_cache.skills)}")
     except Exception as e:
         logger.error(f"无法加载 SkillManager: {e}")
         return None
-    return _skill_manager_cache
+    return _cache.skill_manager_cache
 
 
 def get_core_tools() -> list:
@@ -327,13 +343,11 @@ def get_agent(force_refresh: bool = False) -> LlmAgent:
     Args:
         force_refresh: 是否强制刷新缓存
     """
-    global _agent_cache, _agent_cache_time
-
-    if _agent_cache is None or not _is_cache_valid(_agent_cache_time) or force_refresh:
-        _agent_cache = create_agent()
-        _agent_cache_time = time.time()
-        logger.debug("Agent 缓存已过期或不存在，重新创建")
-    return _agent_cache
+    if _cache.agent_cache is None or not _cache.is_valid(_cache.agent_cache_time) or force_refresh:
+        _cache.agent_cache = create_agent()
+        _cache.agent_cache_time = time.time()
+        logger.debug("对话 Agent 缓存已过期或不存在，重新创建")
+    return _cache.agent_cache
 
 
 # ============================================

--- a/kuma_claw/auth.py
+++ b/kuma_claw/auth.py
@@ -4,6 +4,7 @@ Kuma Claw - OAuth 认证管理
 """
 
 import json
+import logging
 import os
 import secrets
 import threading
@@ -14,6 +15,8 @@ from pathlib import Path
 from urllib.parse import parse_qsl, urlencode, urlparse
 
 import httpx
+
+logger = logging.getLogger("kuma_claw.auth")
 
 # ============================================
 # 配置
@@ -122,7 +125,7 @@ class OAuthTokenManager:
 
             return token_data["access_token"]
         except Exception as e:
-            print(f"刷新 Token 失败: {e}")
+            logger.error(f"刷新 Token 失败: {e}")
             return None
 
     def get_valid_access_token(self, client_id: str, client_secret: str = "") -> str | None:
@@ -155,7 +158,8 @@ class OAuthFlow:
         self.client_id = client_id
         self.client_secret = client_secret
         self.state = secrets.token_urlsafe(16)
-        self.redirect_port = 8080
+        # 使用环境变量配置端口，默认 8080（Issue #107）
+        self.redirect_port = int(os.getenv("KUMA_WEB_PORT", "8080"))
         self.redirect_uri = f"http://localhost:{self.redirect_port}/oauth/callback"
 
     def get_authorization_url(self) -> str:
@@ -247,22 +251,21 @@ class OAuthFlow:
         # 等待服务器启动
         server_ready.wait(timeout=5)
 
-        print("\n🌐 正在打开浏览器进行授权...")
-        print("   如果浏览器没有自动打开，请访问：")
-        print(f"   {auth_url}\n")
+        logger.info(f"授权地址：{auth_url}")
+        logger.info("正在打开浏览器进行授权，如果浏览器没有自动打开，请手动访问上方地址")
 
         # 打开浏览器
         webbrowser.open(auth_url)
 
         # 等待回调
-        print("[dim]等待授权完成...（最多 5 分钟）[/dim]")
+        logger.info("等待授权完成（最多 5 分钟）...")
         server_thread.join(timeout=300)
 
         if callback_received["error"]:
-            print(f"\n[red]❌ 授权失败：{callback_received['error']}[/red]")
+            logger.error(f"授权失败：{callback_received['error']}")
             return False
         elif callback_received["code"]:
-            print("\n[green]✅ 授权成功！正在换取 Token...[/green]")
+            logger.info("授权成功，正在换取 Token...")
             # 用 code 换取 tokens
             tokens = self.exchange_code_for_tokens(callback_received["code"])
             # 保存 tokens
@@ -273,10 +276,10 @@ class OAuthFlow:
                 refresh_token=tokens.get("refresh_token", ""),
                 expires_in=tokens["expires_in"],
             )
-            print("[green]✅ Token 已保存[/green]")
+            logger.info("Token 已保存")
             return True
         else:
-            print("\n[yellow]⚠️  授权超时，请重试[/yellow]")
+            logger.warning("授权超时，请重试")
             return False
 
 

--- a/kuma_claw/config.py
+++ b/kuma_claw/config.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import logging
 import os
+import secrets
 import uuid
 from pathlib import Path
 
@@ -170,10 +171,10 @@ class Config:
                 storage_type = "encrypted-file"
                 stored = True
             except Exception as e:
-                print(f"⚠️ Warning: Failed to store {key}: {e}")
+                logger.warning(f"Failed to store {key}: {e}")
 
         if stored and storage_type != "keyring":
-            print(f"ℹ️ Info: {key} stored in {storage_type} (keyring unavailable)")
+            logger.info(f"{key} stored in {storage_type} (keyring unavailable)")
 
         return stored
 
@@ -257,6 +258,31 @@ class Config:
 
     def get_google_oauth_client_secret(self) -> str | None:
         return self._get_secret("google_oauth_client_secret")
+
+    # ============================================
+    # Web UI Token（Issue #103-2）
+    # ============================================
+
+    def get_web_ui_token(self) -> str | None:
+        """获取 Web UI 访问密码，首次调用时自动生成"""
+        token_file = CONFIG_DIR / "ui_token.txt"
+        if token_file.exists():
+            return token_file.read_text().strip() or None
+        # 首次启动：自动生成并保存
+        new_token = secrets.token_urlsafe(32)
+        token_file.write_text(new_token)
+        token_file.chmod(0o600)
+        logger.info(f"Web UI token generated and saved to {token_file}")
+        return new_token
+
+    # ============================================
+    # 端口配置（Issue #107）
+    # ============================================
+
+    @property
+    def web_ui_port(self) -> int:
+        """获取 Web UI 端口，支持环境变量 KUMA_WEB_PORT 覆盖"""
+        return int(os.getenv("KUMA_WEB_PORT", str(self.config.get("web_ui_port", 8080))))
 
     # ============================================
     # 便捷方法

--- a/kuma_claw/skills/skill_manager.py
+++ b/kuma_claw/skills/skill_manager.py
@@ -270,6 +270,17 @@ class Skill:
                         f"Skill: {self.metadata.get('name', 'unknown')}"
                     )
 
+    def _safe_import(self, name: str, *args, **kwargs):
+        """白名单化的安全 import，防止沙箱逃逸（Issue #103）"""
+        # 只允许 ALLOWED_MODULES 中定义的模块
+        top_level = name.split(".")[0]
+        if name not in self.ALLOWED_MODULES and top_level not in self.ALLOWED_MODULES:
+            raise ImportError(
+                f"Module '{name}' is not allowed in skill sandbox. "
+                f"Allowed modules: {sorted(self.ALLOWED_MODULES)}"
+            )
+        return __import__(name, *args, **kwargs)
+
     def _create_safe_globals(self) -> dict:
         """创建安全的全局命名空间"""
 
@@ -313,7 +324,7 @@ class Skill:
             "tuple": tuple,
             "type": type,
             "zip": zip,
-            "__import__": __import__,
+            "__import__": self._safe_import,
             "Exception": Exception,
             "ValueError": ValueError,
             "TypeError": TypeError,

--- a/kuma_claw/web_ui.py
+++ b/kuma_claw/web_ui.py
@@ -5,12 +5,17 @@ Web UI 启动
 
 import json
 import logging
+import secrets
+from html import escape
 from pathlib import Path
 
 import uvicorn
-from fastapi import FastAPI, Form, Query, Request
+from fastapi import FastAPI, Form, HTTPException, Query, Request
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
 
 from .auth import OAuthFlow, token_manager
 from .config import config
@@ -21,6 +26,109 @@ app = FastAPI(title="Kuma Claw")
 
 TEMPLATES_DIR = Path(__file__).parent / "templates"
 templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
+
+# ============================================
+# 认证中间件（Issue #103-2）
+# ============================================
+
+# 公开路径（无需认证）
+_PUBLIC_PATHS = {"/oauth/callback", "/api/status", "/api/oauth/status"}
+
+
+class WebUIAuthMiddleware(BaseHTTPMiddleware):
+    """简单的 Bearer Token 认证中间件
+
+    防止未授权用户读写 API Key 和配置。
+    Token 在首次启动时自动生成并写入配置目录。
+    """
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        # 公开路径和 OAuth 回调不需要认证
+        if request.url.path in _PUBLIC_PATHS or request.url.path.startswith("/oauth/"):
+            return await call_next(request)
+
+        # 获取当前有效 token
+        expected = config.get_web_ui_token()
+        if not expected:
+            # 未配置 token 时允许访问（首次启动配置阶段）
+            return await call_next(request)
+
+        # 检查 Cookie（浏览器访问）
+        cookie_token = request.cookies.get("kuma_ui_token")
+        if cookie_token and secrets.compare_digest(cookie_token, expected):
+            return await call_next(request)
+
+        # 检查 Authorization header（API 访问）
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.startswith("Bearer "):
+            bearer = auth_header[7:]
+            if secrets.compare_digest(bearer, expected):
+                return await call_next(request)
+
+        # 未认证：返回登录页
+        if request.url.path == "/" or not request.url.path.startswith("/api/"):
+            return RedirectResponse(url="/login")
+        return JSONResponse({"detail": "Unauthorized"}, status_code=401)
+
+
+app.add_middleware(WebUIAuthMiddleware)
+
+
+@app.get("/login", response_class=HTMLResponse)
+async def login_page(request: Request):
+    """登录页面"""
+    return HTMLResponse(
+        content="""
+        <!DOCTYPE html>
+        <html lang="zh-CN">
+        <head>
+            <meta charset="UTF-8">
+            <title>Kuma Claw - 登录</title>
+            <style>
+                body { font-family: sans-serif; display: flex; justify-content: center;
+                       align-items: center; min-height: 100vh; margin: 0;
+                       background: linear-gradient(135deg, #667eea, #764ba2); }
+                .card { background: white; padding: 40px; border-radius: 12px;
+                        box-shadow: 0 4px 20px rgba(0,0,0,0.15); width: 320px; }
+                h1 { text-align: center; color: #333; margin-bottom: 24px; }
+                input { width: 100%; padding: 12px; border: 2px solid #e0e0e0;
+                        border-radius: 8px; font-size: 14px; box-sizing: border-box;
+                        margin-bottom: 16px; }
+                button { width: 100%; padding: 12px; background: linear-gradient(135deg, #667eea, #764ba2);
+                         color: white; border: none; border-radius: 8px;
+                         font-size: 14px; font-weight: 600; cursor: pointer; }
+                .hint { text-align: center; color: #888; font-size: 12px; margin-top: 12px; }
+            </style>
+        </head>
+        <body>
+            <div class="card">
+                <h1>🦞 Kuma Claw</h1>
+                <form method="post" action="/login">
+                    <input type="password" name="token" placeholder="请输入访问密码" required>
+                    <button type="submit">登录</button>
+                </form>
+                <p class="hint">密码保存在 ~/.kuma-claw/ui_token.txt</p>
+            </div>
+        </body>
+        </html>
+        """
+    )
+
+
+@app.post("/login")
+async def login(request: Request, token: str = Form(...)):
+    """处理登录"""
+    expected = config.get_web_ui_token()
+    if not expected or not secrets.compare_digest(token, expected):
+        return HTMLResponse(
+            content="<script>alert('密码错误'); history.back();</script>",
+            status_code=401,
+        )
+    response = RedirectResponse(url="/", status_code=303)
+    response.set_cookie(
+        "kuma_ui_token", token, httponly=True, samesite="lax", max_age=86400 * 7
+    )
+    return response
 
 
 @app.get("/", response_class=HTMLResponse)
@@ -158,7 +266,7 @@ async def oauth_callback(
             <head><title>授权失败</title></head>
             <body style="font-family: sans-serif; text-align: center; padding: 50px;">
                 <h1 style="color: #e74c3c;">❌ 授权失败</h1>
-                <p style="color: #7f8c8d;">错误: {error}</p>
+                <p style="color: #7f8c8d;">错误: {escape(error)}</p>
                 <p><a href="/" style="color: #3498db;">返回首页</a></p>
             </body>
             </html>
@@ -264,7 +372,7 @@ async def oauth_callback(
             <head><title>授权失败</title></head>
             <body style="font-family: sans-serif; text-align: center; padding: 50px;">
                 <h1 style="color: #e74c3c;">❌ 授权失败</h1>
-                <p style="color: #7f8c8d;">Token 交换失败: {str(e)}</p>
+                <p style="color: #7f8c8d;">Token 交换失败: {escape(str(e))}</p>
                 <p><a href="/" style="color: #3498db;">返回首页</a></p>
             </body>
             </html>
@@ -316,9 +424,11 @@ async def oauth_clear():
 # ============================================
 
 
-def start_web_ui(host: str = "0.0.0.0", port: int = 8080):
-    """启动 Web UI"""
-    print(f"🌐 Web UI: http://{host}:{port}")
+def start_web_ui(host: str = "0.0.0.0", port: int | None = None):
+    """启动 Web UI（Issue #107：端口优先从环境变量 KUMA_WEB_PORT 读取）"""
+    if port is None:
+        port = config.web_ui_port
+    logger.info(f"Web UI 已启动： http://{host}:{port}")
     uvicorn.run(app, host=host, port=port, log_level="warning")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,23 +23,24 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 
+# 依赖版本锁定主版本上限，防止破坏性升级（Issue #109）
 dependencies = [
-    "google-adk>=1.0.0",
-    "google-genai>=1.0.0",
-    "slack-bolt>=1.18.0",
-    "python-telegram-bot>=20.0",
-    "fastapi>=0.104.0",
-    "uvicorn>=0.24.0",
-    "websockets>=12.0",
-    "jinja2>=3.1.0",
-    "python-multipart>=0.0.6",
-    "click>=8.1.0",
-    "rich>=13.0.0",
-    "keyring>=24.0.0",
-    "requests>=2.31.0",
-    "python-dotenv>=1.0.0",
-    "duckduckgo-search>=6.0.0",
-    "tenacity>=8.2.0",
+    "google-adk>=1.0.0,<2.0.0",
+    "google-genai>=1.0.0,<2.0.0",
+    "slack-bolt>=1.18.0,<2.0.0",
+    "python-telegram-bot>=20.0,<22.0",
+    "fastapi>=0.104.0,<1.0.0",
+    "uvicorn>=0.24.0,<1.0.0",
+    "websockets>=12.0,<16.0",
+    "jinja2>=3.1.0,<4.0.0",
+    "python-multipart>=0.0.6,<1.0.0",
+    "click>=8.1.0,<9.0.0",
+    "rich>=13.0.0,<15.0.0",
+    "keyring>=24.0.0,<26.0.0",
+    "requests>=2.31.0,<3.0.0",
+    "python-dotenv>=1.0.0,<2.0.0",
+    "duckduckgo-search>=6.0.0,<10.0.0",
+    "tenacity>=8.2.0,<10.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## 概述

本 PR 批量修复了 kuma-claw 中的多个 Issue，涵盖安全漏洞、代码质量、架构重构、配置灵活性和开发体验等方面。

---

## 修复详情

### 🔴 安全修复（Issue #103）

**1. Skill 沙箱逃逸漏洞（严重）**
- `skill_manager.py`：新增 `_safe_import()` 方法，替换 `safe_globals` 中的 `__import__`
- 只允许 `ALLOWED_MODULES` 白名单中的模块被导入，拦截 `__import__("os")` 等逃逸攻击

**2. Web UI 无认证（严重）**
- `web_ui.py`：新增 `WebUIAuthMiddleware` Bearer Token 认证中间件
- `config.py`：新增 `get_web_ui_token()` 方法，首次启动自动生成随机 Token 并保存至 `~/.kuma-claw/ui_token.txt`
- 新增 `/login` 登录页面（Cookie 认证），支持浏览器和 API（Bearer header）两种访问方式
- OAuth 回调、`/api/status` 等公开路径无需认证

**3. OAuth 回调反射型 XSS**
- `web_ui.py`：对 `error` 参数和异常信息使用 `html.escape()` 转义，防止 XSS 注入

---

### 🟡 代码质量（Issue #108）

- `auth.py`：将所有 `print()` 替换为 `logger.info/error/warning`（共 7 处）
- `config.py`：将 `print()` 替换为 `logger.warning/info`（共 2 处）

---

### 🔵 架构重构（Issue #106）

- `agent.py`：将 6 个全局缓存变量（`_model_cache`、`_agent_cache` 等）重构为 `AgentCache` 单例类
- 保留 `reset_cache()` 和 `_is_cache_valid()` 向后兼容接口，不破坏现有调用

---

### 🟢 端口配置（Issue #107）

- `config.py`：新增 `web_ui_port` 属性，优先读取 `KUMA_WEB_PORT` 环境变量
- `auth.py`：`OAuthFlow.redirect_port` 改为从 `KUMA_WEB_PORT` 读取，消除硬编码
- `web_ui.py`：`start_web_ui()` 默认端口改为从 `config.web_ui_port` 读取

---

### 🟢 依赖版本上限（Issue #109）

- `pyproject.toml`：为所有 16 个依赖添加主版本上限（如 `google-adk>=1.0.0,<2.0.0`），防止破坏性升级

---

### 🟢 开发体验（Issue #111）

- 新增 `.pre-commit-config.yaml`，包含 ruff、mypy、pre-commit-hooks
- 安装方式：`pip install pre-commit && pre-commit install`

---

## 测试

所有修改文件均通过 Python AST 语法验证：
- ✅ `kuma_claw/agent.py`
- ✅ `kuma_claw/auth.py`
- ✅ `kuma_claw/config.py`
- ✅ `kuma_claw/web_ui.py`
- ✅ `kuma_claw/skills/skill_manager.py`

## 关联 Issue

Closes #103, #106, #107, #108, #109, #111

> Note: Issue #110（mypy CI）因 GitHub App 缺少 `workflows` 权限无法直接修改 `.github/workflows/ci.yml`，建议仓库所有者手动添加 mypy 步骤（参见 Issue #110 中的建议配置）。
