### PR TITLE
fix(ci): use pyproject.toml for dependency installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pytest-cov
+          pip install ".[dev]"
       
       - name: Run tests
         run: pytest --cov=kuma_claw --cov-report=xml --cov-report=term-missing


### PR DESCRIPTION
## Summary
- CI was failing after #133 because test deps (pytest, pytest-asyncio, pytest-cov) were moved out of requirements.txt into pyproject.toml dev extras
- Changes `pip install -r requirements.txt && pip install pytest-cov` to `pip install .[dev]`
- Single source of truth for all dependencies: pyproject.toml

## Test plan
- [ ] CI passes on all 3 Python versions (3.10, 3.11, 3.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)