### PR TITLE
fix: SECURITY.md 错误引用, CI 添加 mypy, WebAdapter 默认绑定修复

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,22 +41,27 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v4
-      
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      
-      - name: Install ruff
-        run: pip install ruff
-      
+
+      - name: Install dependencies
+        run: |
+          pip install ruff mypy types-requests
+          pip install ".[dev]"
+
       - name: Run ruff check
         run: ruff check kuma_claw --output-format=github
-      
+
       - name: Run ruff format check
         run: ruff format --check kuma_claw
+
+      - name: Run mypy type check
+        run: mypy kuma_claw --ignore-missing-imports --no-error-summary || true
 
   build:
     name: Build

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -230,7 +230,7 @@ KUMA_ALLOWED_DIRS=/tmp,/home/user/.kuma-claw
 ### 代码配置
 
 ```python
-from skills.kuma_skills_system.scripts.skill_manager import SkillManager
+from kuma_claw.skills.skill_manager import SkillManager
 
 # 严格模式（启用所有安全特性）
 manager = SkillManager(
@@ -248,14 +248,11 @@ manager = SkillManager(
 ### 运行安全测试
 
 ```bash
-# 完整测试
-python test_skills_security.py
+# 运行安全相关测试
+pytest tests/test_skill_manager.py -v
 
-# 单项测试
-python -c "
-from test_skills_security import test_path_traversal_protection
-test_path_traversal_protection()
-"
+# 运行全部测试
+pytest
 ```
 
 ### 测试覆盖

--- a/kuma_claw/gateway/adapters/web.py
+++ b/kuma_claw/gateway/adapters/web.py
@@ -29,7 +29,7 @@ class WebAdapter(BaseAdapter):
     def __init__(
         self,
         gateway: Gateway,
-        host: str = "0.0.0.0",
+        host: str = "127.0.0.1",
         port: int = 8080,
     ):
         super().__init__(gateway)


### PR DESCRIPTION
## Summary
- **#131**: SECURITY.md 引用不存在的 `test_skills_security.py` 和错误的 import 路径 `from skills.kuma_skills_system...`，修正为实际路径
- **#110**: CI lint job 添加 mypy 类型检查（`--ignore-missing-imports`，初始以 warning 模式运行不阻塞 CI）
- **#97**: WebAdapter 的 `0.0.0.0` 默认绑定改为 `127.0.0.1`（web_ui.py 已在 #133 修复，这里修补 gateway/adapters/web.py）
- #97 中列出的 6 个安全漏洞已全部在之前的 PR 或本 PR 中解决

Closes #131, #110, #97

## Test plan
- [ ] CI lint job passes (including mypy)
- [ ] CI test job passes
- [ ] SECURITY.md 中的命令可正常运行

🤖 Generated with [Claude Code](https://claude.com/claude-code)